### PR TITLE
fix: update params encoding to use quote instead of quote_plus

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 from aiohttp import ClientSession, ClientError, ClientResponseError
 from typing import Dict, List, Optional
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 from yarl import URL
 
 from azure.identity.aio import DefaultAzureCredential
@@ -173,7 +173,9 @@ class SnykApiClient:
 
         while url:
             try:
-                response_json = await self._get(url, params=urlencode(params, safe=""))
+                response_json = await self._get(
+                    url, params=urlencode(params, safe="", quote_via=quote)
+                )
                 if response_json:
                     data = response_json.get("data")
                     project_ids = [


### PR DESCRIPTION
Quote needs to be used instead of the default value: quote_plus. When spaces are encoded as '+' instead of %20 it results in a 400 status code with the error detailed below:
> Parameter 'names_start_with' must be url encoded. Its value may not contain reserved characters


> _"By default, [quote_plus()](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus) is used to quote the values, which means spaces are quoted as a '+' character and ‘/’ characters are encoded as %2F, which follows the standard for GET requests (application/x-www-form-urlencoded). An alternate function that can be passed as quote_via is [quote()](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote), which will encode spaces as %20 and not encode ‘/’ characters. For maximum control of what is quoted, use quote and specify a value for safe."_


from: https://docs.python.org/3/library/urllib.parse.html#:~:text=b%27a%26%5Cxef%27.-,urllib.parse.urlencode,-(query%2C